### PR TITLE
fix: split join and add method.

### DIFF
--- a/src/main/java/com/devathon/preguntonic/controllers/RoomControllerImpl.java
+++ b/src/main/java/com/devathon/preguntonic/controllers/RoomControllerImpl.java
@@ -51,7 +51,7 @@ public class RoomControllerImpl implements RoomController {
   public ResponseEntity<BasicPlayer> addPlayerRoom(final String roomId, final BasicPlayer player) {
     log.info("Adding player {} to room {}", player.name(), roomId);
     try {
-      return ResponseEntity.ok(roomService.joinRoom(roomId, player));
+      return ResponseEntity.ok(roomService.addRoom(roomId, player));
     } catch (final Exception e) {
       log.warn(ERROR_JOINING_ROOM_MSG, e);
       return ResponseEntity.badRequest().build();

--- a/src/main/java/com/devathon/preguntonic/dto/BasicPlayer.java
+++ b/src/main/java/com/devathon/preguntonic/dto/BasicPlayer.java
@@ -5,6 +5,7 @@
  */
 package com.devathon.preguntonic.dto;
 
+import com.devathon.preguntonic.model.Player;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.UUID;
 import lombok.Builder;
@@ -13,4 +14,13 @@ import lombok.Builder;
 public record BasicPlayer(
     @JsonProperty("playerId") UUID id,
     @JsonProperty("playerName") String name,
-    @JsonProperty String avatar) {}
+    @JsonProperty String avatar) {
+
+  public static BasicPlayer from(final Player player) {
+    return BasicPlayer.builder()
+        .id(player.getId())
+        .name(player.getName())
+        .avatar(player.getAvatar())
+        .build();
+  }
+}

--- a/src/main/java/com/devathon/preguntonic/model/PlayerStatus.java
+++ b/src/main/java/com/devathon/preguntonic/model/PlayerStatus.java
@@ -6,6 +6,7 @@
 package com.devathon.preguntonic.model;
 
 public enum PlayerStatus {
+  CONNECTING, // Connecting to the game server (not in a room)
   IN_LOBBY_UNREADY, // Waiting in the lobby
   IN_LOBBY_READY, // Waiting in the lobby and ready
   IN_GAME, // Playing the game

--- a/src/main/java/com/devathon/preguntonic/services/DummyRoomService.java
+++ b/src/main/java/com/devathon/preguntonic/services/DummyRoomService.java
@@ -59,7 +59,13 @@ public class DummyRoomService implements RoomService {
   }
 
   @Override
-  public BasicPlayer joinRoom(final String roomCode, final BasicPlayer playerInfo) {
+  public BasicPlayer joinRoom(String roomCode, BasicPlayer playerInfo)
+      throws InvalidParameterException {
+    return null;
+  }
+
+  @Override
+  public BasicPlayer addRoom(final String roomCode, final BasicPlayer playerInfo) {
     UUID playerId = Optional.ofNullable(playerInfo.id()).orElse(UUID.randomUUID());
 
     var newPlayer =

--- a/src/main/java/com/devathon/preguntonic/services/RoomService.java
+++ b/src/main/java/com/devathon/preguntonic/services/RoomService.java
@@ -26,14 +26,24 @@ public interface RoomService {
   Optional<Room> getRoom(String roomCode);
 
   /**
-   * Join a room, we are going to add a new user to the room and assign a playerId to it. if the
-   * room does not exist, it will return {@link InvalidParameterException}
+   * Join a room, we are going to change the player status. if room or player does not exist, it
+   * will return {@link InvalidParameterException}
    *
    * @param roomCode the room code
    * @param playerInfo the playerInfo
    * @return the playerInfo id assigned to the new user in the room
    */
   BasicPlayer joinRoom(String roomCode, BasicPlayer playerInfo) throws InvalidParameterException;
+
+  /**
+   * Add a new player to the room and assign a playerId to it. if the room does not exist, it will
+   * return {@link InvalidParameterException}
+   *
+   * @param roomCode the room code
+   * @param playerInfo the playerInfo
+   * @return the playerInfo id assigned to the new user in the room
+   */
+  BasicPlayer addRoom(String roomCode, BasicPlayer playerInfo) throws InvalidParameterException;
 
   /**
    * Change the ready status of a player in a room, if room or player does not exist, it will return

--- a/src/main/java/com/devathon/preguntonic/storage/MemoryRoomStorage.java
+++ b/src/main/java/com/devathon/preguntonic/storage/MemoryRoomStorage.java
@@ -87,6 +87,9 @@ public class MemoryRoomStorage implements RoomStorage {
       log.warn("Room is full: {}", room);
       return Optional.empty();
     }
+    if (room.getCurrentPlayers() == 0) {
+      player.setAdmin(true);
+    }
 
     Player playerSaved = room.addPlayer(player);
     log.info("Player added to room: {}", playerSaved);


### PR DESCRIPTION
split join and add method to avoid null players when the page reloads

## Description

[//]: # (Please include a summary of the change and which issues is fixed. Please also include relevant motivation and context. List any dependencies that are required for change.)

split join and add method to avoid null players when the page reloads.
Also added a new player status when it is added to the room but it hasn't joined yet

## Trello link:

https://trello.com/c/7pliEbQS/<Edit-this>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist
[//]: # (Go over all the following points, and put an `x` in all the boxes that apply.)
[//]: # (If you're unsure about any of these, don't hesitate to ask.)

- [ ] Changes were successfully tested.
- [ ] Dependencies. All dependencies are deployed.

## How Has This Been Tested?

[//]: # (Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration)